### PR TITLE
docs: add planning templates and phase 2 backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a functional problem or regression
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+Describe the bug in one paragraph.
+
+## Steps to reproduce
+1. Go to `...`
+2. Tap `...`
+3. Observe `...`
+
+## Expected result
+What should happen.
+
+## Actual result
+What happens instead.
+
+## Environment
+- App version/branch:
+- Device:
+- OS version:
+
+## Notes
+Screenshots/logs if relevant.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+What user problem are we solving?
+
+## Proposed solution
+Describe the feature behavior and UI flow.
+
+## Acceptance criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Out of scope
+List what should not be included in this ticket.
+
+## Additional context
+Design references, screenshots, or links.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+What changed and why.
+
+## Scope
+- [ ] UI
+- [ ] Data model
+- [ ] Repository/service logic
+- [ ] Navigation/state
+- [ ] Docs
+
+## Validation
+- [ ] `flutter analyze`
+- [ ] `flutter test`
+- [ ] Manual test on device/emulator
+
+## Screenshots / Videos
+Attach if UI changed.
+
+## Risks
+Known tradeoffs or potential regressions.
+
+## Follow-ups
+List any deferred tasks.

--- a/docs/phase_2_backlog.md
+++ b/docs/phase_2_backlog.md
@@ -1,0 +1,32 @@
+# Phase 2 Backlog
+
+This backlog is for post-MVP stabilization and planned enhancements.
+
+## P0 - Stabilize Core UX
+- Fix body heatmap tap precision edge cases (front + back SVG paths).
+- Normalize front/back SVG coordinate systems and document export constraints.
+- Add regression tests for `HeatmapService` muscle mapping and recency bands.
+- Add empty-state UX polish for Calendar/Today/Progress.
+
+## P1 - Data and Reliability
+- Add soft-delete and migration test coverage for Isar models.
+- Add repository-level unit tests (exercise templates, workout sessions).
+- Add backup/export path for local data (JSON export).
+
+## P1 - Firestore Sync (interfaces-first)
+- Keep Isar as source of truth.
+- Implement sync queue model (`pending_create`, `pending_update`, `pending_delete`).
+- Add `SyncRepository` implementation scaffold with no-op sync worker.
+- Define conflict strategy doc (last-write-wins + manual conflict review fallback).
+
+## P2 - Product Improvements
+- Add filters in Heatmap grid (group, stale-first sorting).
+- Add richer Progress cards (7/30 day trend deltas).
+- Add quick templates for Minimum Workout presets.
+
+## Suggested Initial GitHub Issues
+1. `Heatmap hit-test precision and visual alignment`
+2. `Isar repository unit test suite`
+3. `Sync queue data model scaffold`
+4. `Conflict resolution strategy doc`
+5. `Calendar and Today empty-state polish`


### PR DESCRIPTION
## What
- Add issue template: bug report
- Add issue template: feature request
- Add pull request template
- Add Phase 2 backlog doc

## Why
- Standardize planning and collaboration workflow on GitHub
- Make future issues/PRs consistent and faster to write
- Keep roadmap visible in-repo

## Scope
- Docs/process only
- No runtime app code changes

## Validation
- Docs-only change
- No app behavior impact

## Risks
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/process-only additions with no runtime code changes; risk is limited to minor workflow friction if templates are too prescriptive.
> 
> **Overview**
> Adds GitHub workflow templates: new issue templates for `Bug report` and `Feature request`, plus a `PULL_REQUEST_TEMPLATE.md` to standardize PR scope, validation, and risk notes.
> 
> Adds `docs/phase_2_backlog.md` outlining prioritized Phase 2 stabilization and enhancement work (UX fixes, data reliability, and an interfaces-first Firestore sync plan) to keep the roadmap visible in-repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 429bf52d655b14546fc89b3bfc5d0bb0a85eb9a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->